### PR TITLE
Use Hugo's module imports for theme configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated the minimum required Hugo version for this theme to 0.114.0.
+- Refactored the theme configuration in `exampleSite/config/_default/config.yaml`
+  to use Hugo's module imports instead of the `theme` variable. The theme's
+  repository path is now specified under the `imports` section in the `module`
+  block. This change improves clarity and aligns with Hugo's recommended practices
+  for managing theme dependencies.
 
 ## [v0.7.0](https://github.com/sergeyklay/gohugo-theme-ed/compare/v0.6.0...v0.7.0)
 

--- a/exampleSite/config/_default/config.yaml
+++ b/exampleSite/config/_default/config.yaml
@@ -12,10 +12,6 @@ defaultContentLanguage: en
 #     title of the page. Eg. "Contacts - Ed."
 title: Ed.
 
-# Use full path to theme's repository in case of using Hugo Modules.
-# This is replaced in go.mod for exampleSite to point to the directory above.
-theme: github.com/sergeyklay/gohugo-theme-ed
-
 enableRobotsTXT: true
 
 # When using ref or relref to resolve page links and a link cannot
@@ -170,3 +166,7 @@ module:
   hugoVersion:
     extended: true
     min: '0.114.0'
+  imports:
+    # Use full path to theme's repository. This is replaced in go.mod for
+    # exampleSite to point to the directory above.
+    - path: github.com/sergeyklay/gohugo-theme-ed


### PR DESCRIPTION
- Remove the `theme` variable from config.yaml
- Add the theme's repository path to the `imports` section under `module`
- Update comments to clarify the purpose of the `imports` section