### PR TITLE
Replace deprecated --verbose flag with --logLevel info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository path is now specified under the `imports` section in the `module`
   block. This change improves clarity and aligns with Hugo's recommended practices
   for managing theme dependencies.
+- Replaced the deprecated `--verbose` flag with `--logLevel info` in the npm
+  script for `server` in `package.json`. This change addresses a deprecation
+  warning introduced in Hugo v0.114.0, ensuring compatibility with future versions
+  of Hugo.
 
 ## [v0.7.0](https://github.com/sergeyklay/gohugo-theme-ed/compare/v0.6.0...v0.7.0)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Serghei Iakovlev <egrep@protonmail.ch>",
   "main": "index.js",
   "scripts": {
-    "server": "HUGO_RESOURCEDIR='../resources' HUGO_ENV=development hugo server --verbose --source=exampleSite --buildDrafts --buildFuture --ignoreCache --disableFastRender",
+    "server": "HUGO_RESOURCEDIR='../resources' HUGO_ENV=development hugo server --logLevel info --source=exampleSite --buildDrafts --buildFuture --ignoreCache --disableFastRender",
     "test": "playwright test",
     "lint": "npm run lint:js && npm run lint:editorconfig",
     "lint:editorconfig": "editorconfig-checker",


### PR DESCRIPTION
The `--verbose` flag has been deprecated in Hugo v0.114.0 and will be removed in future releases. Update the npm script for 'server' to use `--logLevel info` instead, as per Hugo's recommendation.
