### PR TITLE
Remove CSP error reporting to report-uri.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -101,8 +101,7 @@
     form-action 'self' submit-form.com;
     upgrade-insecure-requests;
     base-uri 'self';
-    manifest-src 'self';
-    report-uri https://egrep.report-uri.com/r/d/csp/enforce"""
+    manifest-src 'self'"""
 
 [[headers]]
   for = '/feeds/*.xml'


### PR DESCRIPTION
### Purpose

report-uri.com is switching to a paid model, [removing the option for free accounts](https://scotthelme.co.uk/report-uri-simplifying-pricing-and-changes-to-free-accounts/). While this is their choice, the current project is non-commercial and lacks the budget to cover $10/month for error reporting services.
