### PR TITLE
Fix error plus typo

### DIFF
--- a/exampleSite/content/documentation/index.md
+++ b/exampleSite/content/documentation/index.md
@@ -423,7 +423,7 @@ To override this list, create file `mini-toc.html` inside `layouts/partials` fol
 
 As you can see, the templating tags `{{ }}` are embedded into the HTML. These tags often use programmatic logic, as is the case here. However, another use of these tags is pull data from your project. In the example above it pulls the `Title` from each allowed post type.
 
-As you may have noticed already, we are basically adapting the blogging features of Hugo to our own ends, what Cuban designer and theorist Ernesto Oroza would call "{{< link src="https://www.ernestooroza.com/" class="external" target="_blank" hreflang="en" rel="noopener noreferrer" >}}technological dissobedience{{< /link >}}".
+As you may have noticed already, we are basically adapting the blogging features of Hugo to our own ends, what Cuban designer and theorist Ernesto Oroza would call "{{< link src="https://www.ernestooroza.com/" class="external" target="_blank" hreflang="en" rel="noopener noreferrer" >}}technological disobedience{{< /link >}}".
 
 The second kind of table of content is exemplified in this documentation. If you open the source file for the documentation, you will notice at the top this snippet:
 

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,74 @@
+[home]
+  other = 'Home'
+
+[more]
+  other = 'Lies mehr...'
+
+[published_on]
+  other = 'Veröffentlicht am'
+
+[updated_on]
+  other = 'Aktualisiert am'
+
+[latest_publications]
+  other = 'Neueste Publikationen'
+
+[your_name]
+  other = 'Ihr Name'
+
+[email_address]
+  other = 'E-Mail Adresse'
+
+[message]
+  other = 'Nachricht'
+
+[edited_by]
+  other = 'Bearbeitet von {{ . }}'
+
+[404_title]
+  other = 'Seite nicht gefunden'
+
+[404_description]
+  other = "Entschuldigung, wir haben die URL verschoben oder sie verweist auf eine Ressource, die nicht existiert."
+
+[404_back]
+  other = 'Gehen Sie zur Startseite zurück und starten dort eine neue Suche'
+
+[by]
+  other = 'von {{ . }}'
+
+[send]
+  other = 'Senden'
+
+[all_publications]
+  other = 'Alle Publikationen'
+
+[publications_tagged]
+  other = 'Publikationen mit Tags "{{ . }}"'
+
+[table_of_contents]
+  other = 'Inhalte'
+
+[search_help]
+  other = "Geben Sie einen Suchbegriff ein um die Website zu durchsuchen."
+
+[search_site]
+  other = 'Website durchsuchen'
+
+[search_no_results]
+  other = 'Keine Resultate gefunden.'
+
+[search_results]
+  other = 'Gefundene Resultate:'
+
+[tag_cloud]
+  other = 'Tag Cloud'
+
+[back_to_top]
+  other = 'Zurück zum Anfang'
+
+[back_to_top_label]
+  other = 'Zurück zum Seitenanfang'
+
+[annotate]
+  other = 'Anmerkung hinzufügen'

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -43,6 +43,6 @@
     {{- template "partials/templates/schema_json.html" . }}
 
     {{- /* Scripts */}}
-    {{- partial "partials/scripts.html" . }}
-    {{- partial "partials/head/analytics.html" . }}
+    {{- partial "scripts.html" . }}
+    {{- partial "head/analytics.html" . }}
 </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   publish = 'public'
 
 [build.environment]
-  HUGO_VERSION = '0.121.0'
+  HUGO_VERSION = '0.147.8'
   HUGO_ENABLEGITINFO = 'true'
 
 # Production context: all deploys from the Production branch


### PR DESCRIPTION
When running example site with latest released hugo version 0.147.8, an error is thrown:

```
WARN  Doubtful use of partial function in {{ partial "partials/scripts.html"}}), ...
```

This PR fixes this issue.
This PR also fixes a typo and provides the German translation.