### PR TITLE
fix: resolve npm audit advisories and bump minimum Hugo to 0.147.8

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
       - main
 
   schedule:
-    - cron: '0 11 * * *'
+    - cron: "0 11 * * *"
       #      | | | | |
       #      | | | | |____ day of the week (0 - 6 or SUN-SAT)
       #      | | | |____ month (1 - 12 or JAN-DEC)
@@ -54,15 +54,15 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.121.0'
+          hugo-version: "0.147.8"
           extended: true
 
       - name: Set up Node 20.x
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
+          node-version: "20.x"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
 
       - name: Install a project with a clean slate
         run: npm ci --ignore-scripts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ on:
       # the push trigger and let them be triggered by the pull_request
       # trigger, avoiding running the workflow twice.  This is a minor
       # optimization so there's no need to ensure this is comprehensive.
-      - 'dependabot/**'
+      - "dependabot/**"
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -27,42 +27,42 @@ jobs:
 
       matrix:
         hugo-version:
-          - '0.121.0'
+          - "0.147.8"
           - latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        # Fetch all history for .GitInfo and .Lastmod
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # Fetch all history for .GitInfo and .Lastmod
+          fetch-depth: 0
 
-    - name: Set up Node 20.x
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20.x'
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
+      - name: Set up Node 20.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20.x"
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
 
-    - name: Install npm dependencies
-      run: npm ci --ignore-scripts
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
 
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
 
-    - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v3
-      with:
-        hugo-version: ${{ matrix.hugo-version }}
-        extended: true
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ matrix.hugo-version }}
+          extended: true
 
-    - name: Run Playwright tests
-      run: npm run test
+      - name: Run Playwright tests
+        run: npm run test
 
-    - name: Upload tests artifact
-      uses: actions/upload-artifact@v7
-      if: always()
-      with:
-        name: playwright-report-hugo-${{ matrix.hugo-version }}
-        path: playwright-report/
-        retention-days: 30
+      - name: Upload tests artifact
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-hugo-${{ matrix.hugo-version }}
+          path: playwright-report/
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/sergeyklay/gohugo-theme-ed/compare/v0.8.1...HEAD)
 
+### Changed
+
+- Updated the minimum required Hugo version for this theme to 0.147.8.
+
 ## [v0.8.1](https://github.com/sergeyklay/gohugo-theme-ed/compare/v0.8.0...v0.8.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the minimum required Hugo version for this theme to 0.147.8.
+- Raised the minimum required Hugo version from 0.121.0 to 0.147.8
+  ([#391](https://github.com/sergeyklay/gohugo-theme-ed/pull/391)).
 
 ## [v0.8.1](https://github.com/sergeyklay/gohugo-theme-ed/compare/v0.8.0...v0.8.1)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ time to complete.
 ### Pull Request Contribution Prerequisites
 
 - You have Node & npm installed
-- You have Hugo installed at v0.121.0+
+- You have Hugo installed at v0.147.8+
 - You are familiar with Git
 
 ### Pull Request Process

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.147.8'
+    min: "0.147.8"
 
   imports:
     - path: github.com/olivernn/lunr.js

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,7 @@
 module:
-
   hugoVersion:
     extended: true
-    min: '0.121.0'
+    min: 0.147.8'
 
   imports:
     - path: github.com/olivernn/lunr.js

--- a/exampleSite/content/poems/a-julia.md
+++ b/exampleSite/content/poems/a-julia.md
@@ -5,7 +5,8 @@ draft: false
 author: Julia de Burgos
 editor: Alex Gil
 source: Ciudad Seva
-contentLang: es
+params:
+  lang: es
 ---
 
 - Ya las gentes murmuran que yo soy tu enemiga

--- a/exampleSite/content/poems/a-julia.md
+++ b/exampleSite/content/poems/a-julia.md
@@ -5,7 +5,7 @@ draft: false
 author: Julia de Burgos
 editor: Alex Gil
 source: Ciudad Seva
-lang: es
+contentLang: es
 ---
 
 - Ya las gentes murmuran que yo soy tu enemiga

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -316,7 +316,7 @@ refLinksErrorLevel = 'WARNING'
 [module]
   [module.hugoVersion]
     extended = true
-    min = '0.121.0'
+    min = '0.147.8'
   [[module.imports]]
     # Use full path to theme's repository. This is replaced in go.mod for
     # exampleSite to point to the directory above.

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -34,7 +34,7 @@
             "objectID" $page.File.UniqueID
             "title" $page.Title
             "href" $page.Permalink
-            "lang" ($page.Params.lang | default $page.Lang)
+            "lang" ($page.Params.contentLang | default $page.Lang)
             "tags" ($page.Params.tags | default slice)
             "kind" $page.Kind
             "type" $page.Type

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -34,7 +34,7 @@
             "objectID" $page.File.UniqueID
             "title" $page.Title
             "href" $page.Permalink
-            "lang" ($page.Params.contentLang | default $page.Lang)
+            "lang" ($page.Params.lang | default $page.Lang)
             "tags" ($page.Params.tags | default slice)
             "kind" $page.Kind
             "type" $page.Type

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -895,10 +895,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1434,9 +1435,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
+      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/theme.toml
+++ b/theme.toml
@@ -44,7 +44,7 @@ features = [
   "simple"
 ]
 
-min_version = "0.121.0"
+min_version = "0.147.8"
 
 # If the theme has a single author.
 [author]


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Fix / Chore

**Intent:** Clear all npm audit security findings in dev dependencies and update the minimum required Hugo version to 0.147.8 to fix a build break caused by Hugo reserving the top-level `lang` front matter key in newer releases.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

`package-lock.json` - lockfile-only changes bump three transitive dev dependencies to patched releases that clear the npm audit findings. No `package.json` changes; no runtime exposure for theme consumers.

`exampleSite/content/poems/a-julia.md` / `config.yaml` - the Hugo version bump required moving the custom `lang: es` value from a top-level front matter key (reserved and now fatal in Hugo 0.147+) to `params.lang`, and raising `min` in every version declaration.

#### Sensitive Areas

- `package-lock.json`: three transitive dep bumps - undici 7.22.0 → 7.27.0, flatted 3.3.1 → 3.4.2, brace-expansion 5.0.4 → 5.0.6
- `.github/workflows/playwright.yml`: pinned Hugo matrix leg updated from 0.121.0 to 0.147.8; YAML indentation normalised
- `.github/workflows/codeql-analysis.yml`: Hugo version updated; YAML string quoting normalised
- `config.yaml`, `exampleSite/hugo.toml`, `theme.toml`, `CONTRIBUTING.md`: minimum Hugo version references updated to 0.147.8
- `exampleSite/content/poems/a-julia.md`: `lang: es` moved under `params:` to avoid Hugo's reserved key handling

### ⚠️ Risk Assessment

- **Breaking Changes:** Yes - minimum required Hugo version raised from 0.121.0 to 0.147.8; sites running Hugo < 0.147.8 will need to upgrade
- **Migrations/State:** No migrations or state changes; authors using a top-level `lang` front matter key in their own content must move it under `params:`