### PR TITLE
chore: clean up dev toolchain config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
           - patch
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions

--- a/assets/js/.eslintrc.yml
+++ b/assets/js/.eslintrc.yml
@@ -1,2 +1,0 @@
-parserOptions:
-  sourceType: module

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.0",
         "@playwright/test": "^1.62.1",
-        "@types/node": "^26.2.0",
+        "@types/node": "^24.13.3",
         "eslint": "^10.8.0",
         "globals": "^17.9.0",
         "jsdom": "^30.0.1"
@@ -450,13 +450,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/acorn": {
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@playwright/test": "^1.62.1",
-    "@types/node": "^26.2.0",
+    "@types/node": "^24.13.3",
     "eslint": "^10.8.0",
     "globals": "^17.9.0",
     "jsdom": "^30.0.1"


### PR DESCRIPTION
### 🎯 Scope & Context

**Type:** Chore

**Intent:** Two unrelated developer-tooling cleanups bundled together: remove a dead ESLint rc file that flat config never loads, and lower `@types/node` so it matches the Node.js 24 runtime pinned everywhere else in the project.

### 🧭 Reviewer Guide

**Complexity:** Low

#### Entry Point

Start with `package.json`. `@types/node` moves from `^26.2.0` to `^24.13.3` (latest 24.x, matching the full-version style already used by the other devDependencies), so the types package no longer advertises APIs the Node 24 runtime does not have. Tests use `// @ts-check`, so this also fixes editor typechecking against the wrong surface. `.github/dependabot.yml` gains an `ignore` rule that blocks only semver-major updates for `@types/node`, keeping minor/patch flowing through the existing npm-minor-patch group while requiring the major to be raised deliberately alongside the runtime. `package-lock.json` reflects the resolved version.

#### Sensitive Areas

- `assets/js/.eslintrc.yml`: deleted. ESLint 10.8.0 uses flat config exclusively and loads only `eslint.config.js` - verified with `npx eslint --debug`, whose config-loader trace mentions `eslint.config.js` only, never the rc file. The removed directive (`parserOptions.sourceType: module`) was redundant anyway, since flat config already defaults `sourceType` to `"module"` for `.js`. It was intentionally not migrated into `eslint.config.js`, which only declares `sourceType` where it deviates from the default (three `commonjs` blocks) - restating the default there would break that convention. Lint output is unchanged.

### ⚠️ Risk Assessment

- **Breaking Changes:** No breaking changes and no runtime impact - both commits touch developer tooling only (ESLint config, `@types/node`, dependabot policy). Theme consumers build with Hugo alone and are unaffected.
- **Migrations/State:** No migrations or state changes. Validated on the final tree: `npm run lint` clean, `npx playwright test` 13/13 passed, `npm run build` exit 0, `dependabot.yml` parses as valid YAML.